### PR TITLE
Add copy functionality for converted service number

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
         <div id="result-section" class="result-section hidden">
             <h2>Converted Service Number:</h2>
             <div id="converted-number" class="converted-number"></div>
+            <button type="button" id="copy-btn" class="secondary-btn">Copy</button>
         </div>
     </div>
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const errorMessage = document.getElementById('error-message');
     const resultSection = document.getElementById('result-section');
     const convertedNumber = document.getElementById('converted-number');
+    const copyBtn = document.getElementById('copy-btn'); // Copy button
 
     // Constants for validation
     const PATTERNS = {
@@ -84,6 +85,18 @@ document.addEventListener('DOMContentLoaded', function() {
         serviceNumberInput.focus();
     }
 
+    /**
+     * Clears all copied converted code to clipboard
+     */
+    function copyToClipboard() {
+        const text = convertedNumber.textContent;
+        navigator.clipboard.writeText(text).then(() => {
+            alert('Copied to clipboard');
+        }).catch(err => {
+            console.error('Failed to copy: ', err);
+        });
+    }
+
     // Event Listeners
     convertBtn.addEventListener('click', function() {
         const input = serviceNumberInput.value.trim();
@@ -128,4 +141,7 @@ document.addEventListener('DOMContentLoaded', function() {
             resultSection.classList.add('hidden');
         }
     });
+    
+    // Copy to clipboard functionality
+    copyBtn.addEventListener('click', copyToClipboard); // Add event listener for copy button
 });


### PR DESCRIPTION
### Summary
This pull request adds a "Copy" button to the Service Number Converter application, allowing users to copy the converted service number to the clipboard.

### Changes
- Added a "Copy" button next to the converted service number in the HTML.
- Implemented `copyToClipboard` function in JavaScript to handle copying the converted service number to the clipboard.
- Added an event listener for the "Copy" button to trigger the copy functionality.
